### PR TITLE
Fixed - issue #8 REPL Selection Message Doesn't Appear Immediately on Startup

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,10 @@ module.exports = (async (cmdPrefix = '%', commands, resultCb, errorCb) => {
         input: process.stdin,
         output: process.stdout
     });
-    
+
+    console.log(`Select first a REPL by using ${cmdPrefix}repl <tag>, i.e: ${cmdPrefix}repl py, ${cmdPrefix}repl node.`);
+    iface.prompt();
+
     iface.on('line', line => {
         if (line.startsWith(cmdPrefix)) {
             const tokens = line.split(' ');


### PR DESCRIPTION
### Description
Closes  - #8 
This PR ensures the immediate printing of `Select first a REPL by using %repl <tag>, i.e: %repl py, %repl node`. just after the `metacall app.js` is entered 

### Result 

![image](https://github.com/user-attachments/assets/701afd92-6a82-4aa0-868c-abb46b465f16)



